### PR TITLE
Add simple RPG web game

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+venv/
+__pycache__/
+*.db
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# myProject2
+# Simple RPG Web Game
+
+A minimal RPG-style web game built with FastAPI, HTMX, TailwindCSS and SQLite.
+
+## Setup
+
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+uvicorn app.main:app --reload
+```
+
+Then open [http://localhost:8000](http://localhost:8000) in your browser.
+
+## Testing
+
+```bash
+pytest
+```

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,30 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from .models import Base, Player, Item
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./game.db")
+
+engine = create_engine(
+    DATABASE_URL, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+def init_db():
+    Base.metadata.create_all(engine)
+    with SessionLocal() as db:
+        if not db.get(Player, 1):
+            db.add(Player(id=1))
+        if db.query(Item).count() == 0:
+            db.add_all([
+                Item(name="Health Potion", cost=20, hp_bonus=20),
+                Item(name="Iron Sword", cost=50, atk_bonus=5),
+            ])
+        db.commit()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,93 @@
+from fastapi import FastAPI, Depends, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.orm import Session
+from .database import init_db, get_db
+from .models import Player, Item
+
+app = FastAPI()
+templates = Jinja2Templates(directory="app/templates")
+
+@app.on_event("startup")
+def on_startup():
+    init_db()
+
+
+def get_player(db: Session) -> Player:
+    return db.get(Player, 1)
+
+
+@app.get("/", response_class=HTMLResponse)
+def read_root(request: Request, db: Session = Depends(get_db)):
+    player = get_player(db)
+    items = db.query(Item).all()
+    return templates.TemplateResponse(
+        "index.html",
+        {"request": request, "player": player, "items": items},
+    )
+
+
+@app.post("/attack", response_class=HTMLResponse)
+def attack(request: Request, db: Session = Depends(get_db)):
+    player = get_player(db)
+    gold_gain = 10
+    exp_gain = 20
+    player.gold += gold_gain
+    player.exp += exp_gain
+    level_up_exp = player.level * 100
+    if player.exp >= level_up_exp:
+        player.exp -= level_up_exp
+        player.level += 1
+        player.hp += 10
+        player.atk += 2
+    db.commit()
+    items = db.query(Item).all()
+    return templates.TemplateResponse(
+        "components/game.html",
+        {
+            "request": request,
+            "player": player,
+            "items": items,
+            "message": f"Attacked monster! +{gold_gain} gold, +{exp_gain} exp.",
+        },
+    )
+
+
+@app.post("/upgrade", response_class=HTMLResponse)
+def upgrade(request: Request, db: Session = Depends(get_db)):
+    player = get_player(db)
+    cost = player.weapon_level * 50
+    message = ""
+    if player.gold >= cost:
+        player.gold -= cost
+        player.weapon_level += 1
+        player.atk += 5
+        db.commit()
+        message = f"Upgraded weapon to level {player.weapon_level}!"
+    else:
+        message = "Not enough gold."
+    items = db.query(Item).all()
+    return templates.TemplateResponse(
+        "components/game.html",
+        {"request": request, "player": player, "items": items, "message": message},
+    )
+
+
+@app.post("/buy/{item_id}", response_class=HTMLResponse)
+def buy_item(item_id: int, request: Request, db: Session = Depends(get_db)):
+    player = get_player(db)
+    item = db.get(Item, item_id)
+    message = ""
+    if item and player.gold >= item.cost:
+        player.gold -= item.cost
+        player.atk += item.atk_bonus
+        player.hp += item.hp_bonus
+        db.commit()
+        message = f"Purchased {item.name}!"
+    else:
+        message = "Cannot buy item."
+    items = db.query(Item).all()
+    return templates.TemplateResponse(
+        "components/game.html",
+        {"request": request, "player": player, "items": items, "message": message},
+    )

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,22 @@
+from sqlalchemy.orm import declarative_base
+from sqlalchemy import Column, Integer, String
+
+Base = declarative_base()
+
+class Player(Base):
+    __tablename__ = "players"
+    id = Column(Integer, primary_key=True)
+    hp = Column(Integer, default=100)
+    atk = Column(Integer, default=10)
+    level = Column(Integer, default=1)
+    exp = Column(Integer, default=0)
+    gold = Column(Integer, default=0)
+    weapon_level = Column(Integer, default=1)
+
+class Item(Base):
+    __tablename__ = "items"
+    id = Column(Integer, primary_key=True)
+    name = Column(String, unique=True)
+    cost = Column(Integer)
+    atk_bonus = Column(Integer, default=0)
+    hp_bonus = Column(Integer, default=0)

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8" />
+    <title>Simple RPG</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/htmx.org@1.9.2"></script>
+</head>
+<body class="p-4">
+    {% block body %}{% endblock %}
+</body>
+</html>

--- a/app/templates/components/game.html
+++ b/app/templates/components/game.html
@@ -1,0 +1,33 @@
+<div class="space-y-4">
+    {% if message %}
+    <div class="text-green-600">{{ message }}</div>
+    {% endif %}
+    <div id="stats" class="border p-2">
+        <p>HP: {{ player.hp }}</p>
+        <p>ATK: {{ player.atk }}</p>
+        <p>Level: {{ player.level }}</p>
+        <p>EXP: {{ player.exp }}</p>
+        <p>Gold: {{ player.gold }}</p>
+    </div>
+    <div class="flex space-x-2">
+        <form hx-post="/attack" hx-target="#game" hx-swap="outerHTML">
+            <button class="bg-blue-500 text-white px-2 py-1">Attack</button>
+        </form>
+        <form hx-post="/upgrade" hx-target="#game" hx-swap="outerHTML">
+            <button class="bg-purple-500 text-white px-2 py-1">Upgrade Weapon (cost {{ player.weapon_level*50 }})</button>
+        </form>
+    </div>
+    <div>
+        <h2 class="font-bold">Shop</h2>
+        <ul>
+        {% for item in items %}
+            <li>
+                {{ item.name }} - {{ item.cost }} gold
+                <form hx-post="/buy/{{ item.id }}" hx-target="#game" hx-swap="outerHTML" class="inline">
+                    <button class="bg-green-500 text-white px-2 py-1">Buy</button>
+                </form>
+            </li>
+        {% endfor %}
+        </ul>
+    </div>
+</div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+{% block body %}
+<div id="game">
+    {% include "components/game.html" %}
+</div>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn
+jinja2
+sqlalchemy
+requests
+pytest
+httpx

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -1,0 +1,32 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+os.environ["DATABASE_URL"] = "sqlite:///./test.db"
+
+from app.main import app
+from fastapi.testclient import TestClient
+from app.database import SessionLocal, init_db
+from app.models import Player
+
+client = TestClient(app)
+
+
+def setup_function(function):
+    if os.path.exists("test.db"):
+        os.remove("test.db")
+    init_db()
+
+
+def teardown_function(function):
+    if os.path.exists("test.db"):
+        os.remove("test.db")
+
+
+def test_attack_increases_gold_and_exp():
+    response = client.post("/attack")
+    assert response.status_code == 200
+    with SessionLocal() as db:
+        player = db.get(Player, 1)
+        assert player.gold == 10
+        assert player.exp == 20


### PR DESCRIPTION
## Summary
- implement FastAPI RPG with attack, equipment upgrades, and shop
- use SQLite models with HTMX/Tailwind templates
- add tests and setup instructions

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a447670b408328ae7821f57a036b47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduces a Simple RPG web app with a homepage showing player stats, attack action, weapon upgrades, and a shop for items. Dynamic UI updates via HTMX, styled with Tailwind. Data is persisted in SQLite and initialized with starter content.
* **Documentation**
  * Updated README with setup, run (local URL), and testing instructions.
* **Tests**
  * Added integration test covering the attack flow.
* **Chores**
  * Added Python .gitignore and project dependencies list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->